### PR TITLE
Partition by day

### DIFF
--- a/.docs/Using-the-CLI.md
+++ b/.docs/Using-the-CLI.md
@@ -133,7 +133,7 @@ Here is the full list of supported template tokens:
 
 #### Partitioning
 
-You can use partitioning to split files after a given number of messages or file size.
+You can use partitioning to split files after a given number of messages, file size or unit of time.
 For example, a channel with 36 messages set to be partitioned every 10 messages will output 4 files.
 
 ```console
@@ -144,6 +144,11 @@ A 45 MB channel set to be partitioned every 20 MB will output 3 files.
 
 ```console
 ./DiscordChatExporter.Cli export -t "mfa.Ifrn" -c 53555 -p 20mb
+```
+
+And a decently active channel that has existed over the course of 7 days will output 7 files.
+```console
+./DiscordChatExporter.Cli export -t "mra.Ifrn" -c 53555 -p day
 ```
 
 #### Downloading assets

--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -59,7 +59,7 @@ public abstract class ExportCommandBase : DiscordCommandBase
         "partition",
         'p',
         Description = "Split the output into partitions, each limited to the specified "
-            + "number of messages (e.g. '100') or file size (e.g. '10mb')."
+            + "number of messages (e.g. '100'), file size (e.g. '10mb') or unit of time (e.g 'day')."
     )]
     public PartitionLimit PartitionLimit { get; init; } = PartitionLimit.Null;
 

--- a/DiscordChatExporter.Core/Exporting/ExportContext.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportContext.cs
@@ -13,7 +13,7 @@ using DiscordChatExporter.Core.Utils.Extensions;
 
 namespace DiscordChatExporter.Core.Exporting;
 
-internal class ExportContext(DiscordClient discord, ExportRequest request)
+public class ExportContext(DiscordClient discord, ExportRequest request)
 {
     private readonly Dictionary<Snowflake, Member?> _membersById = new();
     private readonly Dictionary<Snowflake, Channel> _channelsById = new();

--- a/DiscordChatExporter.Core/Exporting/MessageExporter.cs
+++ b/DiscordChatExporter.Core/Exporting/MessageExporter.cs
@@ -65,8 +65,11 @@ internal partial class MessageExporter(ExportContext context) : IAsyncDisposable
         CancellationToken cancellationToken = default
     )
     {
+        context.Request.PartitionLimit.Update(message, context);
+
         var writer = await InitializeWriterAsync(cancellationToken);
         await writer.WriteMessageAsync(message, cancellationToken);
+
         MessagesExported++;
     }
 

--- a/DiscordChatExporter.Core/Exporting/Partitioning/DayPartitionLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/Partitioning/DayPartitionLimit.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using DiscordChatExporter.Core.Discord.Data;
+
+namespace DiscordChatExporter.Core.Exporting.Partitioning;
+
+internal class DayPartitionLimit() : PartitionLimit
+{
+    private DateTimeOffset? CurrentDay = null;
+
+    // Fucking kill me my code is ASS
+    private bool ForceSplitFlag = false;
+
+    public override bool IsReached(long messagesWritten, long bytesWritten) => ForceSplitFlag;
+
+    public override void Update(Message message, ExportContext context)
+    {
+        ForceSplitFlag = false;
+
+        DateTimeOffset messageDate = context.NormalizeDate(message.Timestamp);
+        CurrentDay ??= messageDate;
+
+        if (messageDate.Date != CurrentDay?.Date)
+        {
+            CurrentDay = messageDate;
+            ForceSplitFlag = true;
+        }
+    }
+}

--- a/DiscordChatExporter.Core/Exporting/Partitioning/FileSizePartitionLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/Partitioning/FileSizePartitionLimit.cs
@@ -1,7 +1,11 @@
-﻿namespace DiscordChatExporter.Core.Exporting.Partitioning;
+﻿using DiscordChatExporter.Core.Discord.Data;
+
+namespace DiscordChatExporter.Core.Exporting.Partitioning;
 
 internal class FileSizePartitionLimit(long limit) : PartitionLimit
 {
     public override bool IsReached(long messagesWritten, long bytesWritten) =>
         bytesWritten >= limit;
+
+    public override void Update(Message message, ExportContext context) { }
 }

--- a/DiscordChatExporter.Core/Exporting/Partitioning/MessageCountPartitionLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/Partitioning/MessageCountPartitionLimit.cs
@@ -1,7 +1,11 @@
-﻿namespace DiscordChatExporter.Core.Exporting.Partitioning;
+﻿using DiscordChatExporter.Core.Discord.Data;
+
+namespace DiscordChatExporter.Core.Exporting.Partitioning;
 
 internal class MessageCountPartitionLimit(long limit) : PartitionLimit
 {
     public override bool IsReached(long messagesWritten, long bytesWritten) =>
         messagesWritten >= limit;
+
+    public override void Update(Message message, ExportContext context) { }
 }

--- a/DiscordChatExporter.Core/Exporting/Partitioning/MonthPartitionLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/Partitioning/MonthPartitionLimit.cs
@@ -1,0 +1,28 @@
+using System;
+using DiscordChatExporter.Core.Discord.Data;
+
+namespace DiscordChatExporter.Core.Exporting.Partitioning;
+
+internal class MonthPartitionLimit() : PartitionLimit
+{
+    private DateTimeOffset? CurrentDate = null;
+
+    // Fucking kill me my code is ASS
+    private bool ForceSplitFlag = false;
+
+    public override bool IsReached(long messagesWritten, long bytesWritten) => ForceSplitFlag;
+
+    public override void Update(Message message, ExportContext context)
+    {
+        ForceSplitFlag = false;
+
+        DateTimeOffset messageDate = context.NormalizeDate(message.Timestamp);
+        CurrentDate ??= messageDate;
+
+        if (messageDate.Month != CurrentDate?.Month)
+        {
+            CurrentDate = messageDate;
+            ForceSplitFlag = true;
+        }
+    }
+}

--- a/DiscordChatExporter.Core/Exporting/Partitioning/NullPartitionLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/Partitioning/NullPartitionLimit.cs
@@ -1,6 +1,10 @@
-﻿namespace DiscordChatExporter.Core.Exporting.Partitioning;
+﻿using DiscordChatExporter.Core.Discord.Data;
+
+namespace DiscordChatExporter.Core.Exporting.Partitioning;
 
 internal class NullPartitionLimit : PartitionLimit
 {
     public override bool IsReached(long messagesWritten, long bytesWritten) => false;
+
+    public override void Update(Message message, ExportContext context) { }
 }

--- a/DiscordChatExporter.Core/Exporting/Partitioning/PartitionLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/Partitioning/PartitionLimit.cs
@@ -62,6 +62,9 @@ public partial class PartitionLimit
         if (value.Equals("day"))
             return new DayPartitionLimit();
 
+        if (value.Equals("year"))
+            return new YearPartitionLimit();
+
         return null;
     }
 

--- a/DiscordChatExporter.Core/Exporting/Partitioning/PartitionLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/Partitioning/PartitionLimit.cs
@@ -59,13 +59,13 @@ public partial class PartitionLimit
         if (int.TryParse(value, NumberStyles.Integer, formatProvider, out var messageCountLimit))
             return new MessageCountPartitionLimit(messageCountLimit);
 
-        if (value.Equals("day"))
-            return new DayPartitionLimit();
-
-        if (value.Equals("year"))
-            return new YearPartitionLimit();
-
-        return null;
+        return value switch
+        {
+            "day" => new DayPartitionLimit(),
+            "month" => new MonthPartitionLimit(),
+            "year" => new YearPartitionLimit(),
+            _ => null,
+        };
     }
 
     public static PartitionLimit Parse(string value, IFormatProvider? formatProvider = null) =>

--- a/DiscordChatExporter.Core/Exporting/Partitioning/PartitionLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/Partitioning/PartitionLimit.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using DiscordChatExporter.Core.Discord.Data;
 
 namespace DiscordChatExporter.Core.Exporting.Partitioning;
 
 public abstract partial class PartitionLimit
 {
     public abstract bool IsReached(long messagesWritten, long bytesWritten);
+    public abstract void Update(Message message, ExportContext context);
 }
 
 public partial class PartitionLimit
@@ -56,6 +58,9 @@ public partial class PartitionLimit
 
         if (int.TryParse(value, NumberStyles.Integer, formatProvider, out var messageCountLimit))
             return new MessageCountPartitionLimit(messageCountLimit);
+
+        if (value.Equals("day"))
+            return new DayPartitionLimit();
 
         return null;
     }

--- a/DiscordChatExporter.Core/Exporting/Partitioning/YearPartitionLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/Partitioning/YearPartitionLimit.cs
@@ -3,9 +3,9 @@ using DiscordChatExporter.Core.Discord.Data;
 
 namespace DiscordChatExporter.Core.Exporting.Partitioning;
 
-internal class DayPartitionLimit() : PartitionLimit
+internal class YearPartitionLimit() : PartitionLimit
 {
-    private DateTimeOffset? CurrentDay = null;
+    private DateTimeOffset? CurrentDate = null;
 
     // Fucking kill me my code is ASS
     private bool ForceSplitFlag = false;
@@ -17,11 +17,11 @@ internal class DayPartitionLimit() : PartitionLimit
         ForceSplitFlag = false;
 
         DateTimeOffset messageDate = context.NormalizeDate(message.Timestamp);
-        CurrentDay ??= messageDate;
+        CurrentDate ??= messageDate;
 
-        if (messageDate.Date != CurrentDay?.Date)
+        if (messageDate.Year != CurrentDate?.Year)
         {
-            CurrentDay = messageDate;
+            CurrentDate = messageDate;
             ForceSplitFlag = true;
         }
     }

--- a/DiscordChatExporter.Core/Exporting/PlainTextMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/PlainTextMessageWriter.cs
@@ -43,7 +43,6 @@ internal class PlainTextMessageWriter(Stream stream, ExportContext context)
         if (message.IsPinned)
             await _writer.WriteAsync(" (pinned)");
 
-
         await _writer.WriteLineAsync();
     }
 


### PR DESCRIPTION
Adds the ability to partition chat exports by one of three units of time (days, months, and years).
